### PR TITLE
Update eip-1459.md

### DIFF
--- a/EIPS/eip-1459.md
+++ b/EIPS/eip-1459.md
@@ -1,7 +1,8 @@
 ---
 eip: 1459
 title: Node Discovery via DNS
-author: Felix Lange <fjl@ethereum.org>, Péter Szilágyi <peter@ethereum.org>
+description: Scheme for authenticated updateable Ethereum node lists via DNS.
+author: Martin Holst Swende (@holiman), Felix Lange <fjl@ethereum.org>, Péter Szilágyi <peter@ethereum.org>
 type: Standards Track
 category: Networking
 status: Review
@@ -10,12 +11,12 @@ requires: 778
 discussions-to: https://github.com/ethereum/devp2p/issues/50
 ---
 
-# Abstract
+## Abstract
 
 This document describes a scheme for authenticated, updateable Ethereum node
 lists retrievable via DNS.
 
-# Motivation
+## Motivation
 
 Many Ethereum clients contain hard-coded bootstrap node lists. Updating those
 lists requires a software update. The current lists are small, giving the client
@@ -30,7 +31,7 @@ can't join the DHT due to restrictive network policy. DNS-based node lists may
 also be useful to Ethereum peering providers because their customers can
 configure the client to use the provider's list.
 
-# Specification
+## Specification
 
 A 'node list' is a list of 'node records' [as defined by EIP-778](./eip-778.md)
 of arbitrary length. Lists
@@ -41,7 +42,7 @@ in order to verify the list.
 To refer to a DNS node list, clients use a URL with 'enrtree' scheme. The URL
 contains the DNS name on which the list can be found as well as the public key
 that signed the list. The public key is contained in the username part of the
-URL and is the base32 encoding of the compressed 32-byte binary public key.
+URL and is the base32 encoding (RFC-4648) of the compressed 32-byte binary public key.
 
 Example:
 
@@ -51,7 +52,7 @@ This URL refers to a node list at the DNS name 'nodes.example.org' and is signed
 by the public key
 `0x049f88229042fef9200246f49f94d9b77c4e954721442714e85850cb6d9e5daf2d880ea0e53cb3ac1a75f9923c2726a4f941f7d326781baa6380754a360de5c2b6`
 
-## DNS Record Structure
+### DNS Record Structure
 
 The nodes in a list are encoded as a merkle tree for distribution via the DNS
 protocol. Entries of the merkle tree are contained in DNS TXT records. The root
@@ -65,7 +66,7 @@ where
   nodes and links subtrees.
 - `sequence-number` is the tree's update sequence number, a decimal integer.
 - `signature` is a 65-byte secp256k1 EC signature over the keccak256 hash of the
-  record content, excluding the `sig=` part, encoded as URL-safe base64.
+  record content, excluding the `sig=` part, encoded as URL-safe base64 (RFC-4648).
 
 Further TXT records on subdomains map hashes to one of three entry types. The
 subdomain name of any entry is the base32 encoding of the (abbreviated)
@@ -99,7 +100,7 @@ H4FHT4B454P6UXFD7JCYQ5PWDY    86900   IN    TXT   enr:-HW4QAggRauloj2SDLtIHN1XBk
 MHTDO6TMUBRIA2XWG5LUDACK24    86900   IN    TXT   enr:-HW4QLAYqmrwllBEnzWWs7I5Ev2IAs7x_dZlbYdRdMUx5EyKHDXp7AV5CkuPGUPdvbv1_Ms1CPfhcGCvSElSosZmyoqAgmlkgnY0iXNlY3AyNTZrMaECriawHKWdDRk2xeZkrOXBQ0dfMFLHY4eENZwdufn1S1o
 ```
 
-## Client Protocol
+### Client Protocol
 
 To find nodes at a given DNS name, say "mynodes.org":
 
@@ -124,7 +125,7 @@ Client implementations should avoid downloading the entire tree at once during
 normal operation. It's much better to request entries via DNS when-needed, i.e.
 at the time when the client is looking for peers.
 
-# Rationale
+## Rationale
 
 ### Why DNS?
 
@@ -162,12 +163,6 @@ enable client implementations to sync these trees independently. A client
 wanting to get as many nodes as possible will sync the link tree first and add
 all linked names to the sync horizon.
 
-# References
-
-1. The base64 and base32 encodings used to represent binary data are defined in
-   [RFC 4648](https://tools.ietf.org/html/rfc4648). No padding is used for base64
-   and base32 data.
-
-# Copyright
+## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
At least one author needs to have a GitHub handle.  I added @holiman here because they are the one submitting the PR, but instead you could just put in Felix's or Péter's GitHub handle.

I adjusted the headings to match the template (two `##` instead of one `#`).

Removed References section which isn't part of the EIP template.

If padding is an optional part of base64/base32 then the fact that padding isn't used should be mentioned in the specification section.

I moved the reference to RFC-4648 inline on first mention of each of base32 and base64.  No link included since it is trivially easy to find RFCs online so the external link (which is generally not allowed) is unnecessary in this case.